### PR TITLE
add safety check for missing file

### DIFF
--- a/c_src/hnswlib_nif.cpp
+++ b/c_src/hnswlib_nif.cpp
@@ -59,6 +59,7 @@ static ERL_NIF_TERM hnswlib_index_new(ErlNifEnv *env, int argc, const ERL_NIF_TE
     } catch (std::runtime_error &err) {
         if (index->val) {
             delete index->val;
+            index->val = nullptr;
         }
         enif_release_resource(index);
         return erlang::nif::error(env, err.what());
@@ -229,15 +230,15 @@ static ERL_NIF_TERM hnswlib_index_load_index(ErlNifEnv *env, int argc, const ERL
         index->val->loadIndex(path, max_elements, allow_replace_deleted);
 
         ret = erlang::nif::ok(env, enif_make_resource(env, index));
-        enif_release_resource(index);
     } catch (std::runtime_error &err) {
         if (index->val) {
             delete index->val;
+            index->val = nullptr;
         }
-        enif_release_resource(index);
         ret = erlang::nif::error(env, err.what());
     }
     enif_rwlock_rwunlock(index->rwlock);
+    enif_release_resource(index);
 
     return ret;
 }
@@ -513,6 +514,7 @@ static ERL_NIF_TERM hnswlib_bfindex_new(ErlNifEnv *env, int argc, const ERL_NIF_
     } catch (std::runtime_error &err) {
         if (index->val) {
             delete index->val;
+            index->val = nullptr;
         }
         enif_release_resource(index);
         return erlang::nif::error(env, err.what());
@@ -686,15 +688,15 @@ static ERL_NIF_TERM hnswlib_bfindex_load_index(ErlNifEnv *env, int argc, const E
         index->val->loadIndex(path, max_elements);
         
         ret = erlang::nif::ok(env, enif_make_resource(env, index));
-        enif_release_resource(index);
     } catch (std::runtime_error &err) {
         if (index->val) {
             delete index->val;
+            index->val = nullptr;
         }
         ret = erlang::nif::error(env, err.what());
-        enif_release_resource(index);
     }
     enif_rwlock_runlock(index->rwlock);
+    enif_release_resource(index);
 
     return ret;
 }

--- a/lib/hnswlib_index.ex
+++ b/lib/hnswlib_index.ex
@@ -248,8 +248,7 @@ defmodule HNSWLib.Index do
     max_elements = Helper.get_keyword!(opts, :max_elements, :non_neg_integer, 0)
     allow_replace_deleted = Helper.get_keyword!(opts, :allow_replace_deleted, :boolean, false)
 
-    with {:existence_check, true} <- {:existence_check, File.exists?(path)},
-         {:ok, ref} <-
+    with {:ok, ref} <-
            HNSWLib.Nif.index_load_index(space, dim, path, max_elements, allow_replace_deleted) do
       {:ok,
        %T{
@@ -258,9 +257,6 @@ defmodule HNSWLib.Index do
          reference: ref
        }}
     else
-      {:existence_check, _} ->
-        {:error, "no_file"}
-
       {:error, reason} ->
         {:error, reason}
     end

--- a/lib/hnswlib_index.ex
+++ b/lib/hnswlib_index.ex
@@ -248,9 +248,8 @@ defmodule HNSWLib.Index do
     max_elements = Helper.get_keyword!(opts, :max_elements, :non_neg_integer, 0)
     allow_replace_deleted = Helper.get_keyword!(opts, :allow_replace_deleted, :boolean, false)
 
-    HNSWLib.Nif.index_load_index(space, dim, path, max_elements, allow_replace_deleted)
-
-    with {:ok, ref} <-
+    with {:existence_check, true} <- {:existence_check, File.exists?(path)},
+         {:ok, ref} <-
            HNSWLib.Nif.index_load_index(space, dim, path, max_elements, allow_replace_deleted) do
       {:ok,
        %T{
@@ -259,6 +258,9 @@ defmodule HNSWLib.Index do
          reference: ref
        }}
     else
+      {:existence_check, _} ->
+        {:error, "no_file"}
+
       {:error, reason} ->
         {:error, reason}
     end

--- a/test/hnswlib_index_test.exs
+++ b/test/hnswlib_index_test.exs
@@ -622,7 +622,7 @@ defmodule HNSWLib.Index.Test do
   test "HNSWLib.Index.load_index/3 with missing file" do
     bad_filepath = "this/file/doesnt/exist"
     refute File.exists?(bad_filepath)
-    assert {:error, "no_file"} = HNSWLib.Index.load_index(:l2, 2, bad_filepath)
+    assert {:error, "Cannot open file"} = HNSWLib.Index.load_index(:l2, 2, bad_filepath)
   end
 
   test "HNSWLib.Index.mark_deleted/2" do

--- a/test/hnswlib_index_test.exs
+++ b/test/hnswlib_index_test.exs
@@ -619,6 +619,12 @@ defmodule HNSWLib.Index.Test do
     File.rm(save_to)
   end
 
+  test "HNSWLib.Index.load_index/3 with missing file" do
+    bad_filepath = "this/file/doesnt/exist"
+    refute File.exists?(bad_filepath)
+    assert {:error, "no_file"} = HNSWLib.Index.load_index(:l2, 2, bad_filepath)
+  end
+
   test "HNSWLib.Index.mark_deleted/2" do
     space = :ip
     dim = 2


### PR DESCRIPTION
`HNSWLib.Index.load_index/3` fails with a seg fault if the filepath points to a file that is either missing or corrupted. This checks to ensure the file exists before attempting to read it.