### PR TITLE
Clean up the priv directory between different targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,3 +51,7 @@ $(NIF_SO):
 				cp "$(CMAKE_HNSWLIB_BUILD_DIR)/hnswlib_nif.so" "$(NIF_SO)" ; \
 			fi ; \
 		fi
+
+cleanup:
+	@ rm -rf "$(CMAKE_HNSWLIB_BUILD_DIR)"
+	@ rm -rf "$(NIF_SO)"

--- a/Makefile.win
+++ b/Makefile.win
@@ -53,9 +53,5 @@ $(NIF_SO):
 	)
 
 cleanup:
-	@ if exist "$(NIF_SO)" ( \
-		del /f "$(NIF_SO)" \
-	)
-	@ if exist "$(CMAKE_HNSWLIB_BUILD_DIR)" ( \
-		rd  /S /Q "$(CMAKE_HNSWLIB_BUILD_DIR)" \
-	)
+	@ powershell -command "if (Test-Path \"$(NIF_SO)\" -PathType Leaf) { Remove-Item \"$(NIF_SO)\" }"
+	@ powershell -command "if (Test-Path \"$(CMAKE_HNSWLIB_BUILD_DIR)\" ) { Remove-Item \"$(CMAKE_HNSWLIB_BUILD_DIR)\" -Recurse -Force }

--- a/Makefile.win
+++ b/Makefile.win
@@ -51,3 +51,11 @@ $(NIF_SO):
 		cmake --build . $(CMAKE_BUILD_PARAMETER) && \
 		cmake --install . $(CMAKE_BUILD_PARAMETER) \
 	)
+
+cleanup:
+	@ if exist "$(NIF_SO)" ( \
+		del /f "$(NIF_SO)" \
+	)
+	@ if exist "$(CMAKE_HNSWLIB_BUILD_DIR)" ( \
+		rd  /S /Q "$(CMAKE_HNSWLIB_BUILD_DIR)" \
+	)

--- a/c_src/nif_utils.cpp
+++ b/c_src/nif_utils.cpp
@@ -96,7 +96,7 @@ int get(ErlNifEnv *env, ERL_NIF_TERM term, unsigned long long *var) {
     return enif_get_uint64(env, term, reinterpret_cast<ErlNifUInt64 *>(var));
 }
 
-int get(ErlNifEnv *env, ERL_NIF_TERM term, long *var) {
+int get(ErlNifEnv *env, ERL_Nfint make(ErlNifEnv *env, const std::vector<size_t>& array, ERL_NIF_TERM &out)IF_TERM term, long *var) {
     return enif_get_int64(env, term, reinterpret_cast<ErlNifSInt64 *>(var));
 }
 
@@ -266,12 +266,12 @@ int make(ErlNifEnv *env, const std::vector<long long>& array, ERL_NIF_TERM &out)
     return make_i64_list_from_c_array(env, count, data, out);
 }
 
-int make(ErlNifEnv *env, const std::vector<size_t>& array, ERL_NIF_TERM &out) {
+int make(ErlNifEnv *env, const std::vector<unsigned long int>& array, ERL_NIF_TERM &out) {
     size_t count = array.size();
-    if (sizeof(size_t) == 8) {
+    if (sizeof(unsigned long int) == 8) {
         uint64_t * data = (uint64_t *)array.data();
         return make_u64_list_from_c_array(env, count, data, out);
-    } else if (sizeof(size_t) == 4) {
+    } else if (sizeof(unsigned long int) == 4) {
         uint32_t * data = (uint32_t *)array.data();
         return make_u32_list_from_c_array(env, count, data, out);
     } else {

--- a/c_src/nif_utils.cpp
+++ b/c_src/nif_utils.cpp
@@ -96,7 +96,7 @@ int get(ErlNifEnv *env, ERL_NIF_TERM term, unsigned long long *var) {
     return enif_get_uint64(env, term, reinterpret_cast<ErlNifUInt64 *>(var));
 }
 
-int get(ErlNifEnv *env, ERL_Nfint make(ErlNifEnv *env, const std::vector<size_t>& array, ERL_NIF_TERM &out)IF_TERM term, long *var) {
+int get(ErlNifEnv *env, ERL_NIF_TERM term, long *var) {
     return enif_get_int64(env, term, reinterpret_cast<ErlNifSInt64 *>(var));
 }
 

--- a/c_src/nif_utils.cpp
+++ b/c_src/nif_utils.cpp
@@ -234,13 +234,11 @@ int make(ErlNifEnv *env, const std::vector<uint32_t>& array, ERL_NIF_TERM &out) 
     return make_u32_list_from_c_array(env, count, data, out);
 }
 
-#ifndef OS_WIN
 int make(ErlNifEnv *env, const std::vector<unsigned long long>& array, ERL_NIF_TERM &out) {
     size_t count = array.size();
     uint64_t * data = (uint64_t *)array.data();
     return make_u64_list_from_c_array(env, count, data, out);
 }
-#endif
 
 int make(ErlNifEnv *env, const std::vector<int8_t>& array, ERL_NIF_TERM &out) {
     size_t count = array.size();

--- a/c_src/nif_utils.hpp
+++ b/c_src/nif_utils.hpp
@@ -173,7 +173,7 @@ int make(ErlNifEnv *env, const std::vector<int8_t>& array, ERL_NIF_TERM &out);
 int make(ErlNifEnv *env, const std::vector<int16_t>& array, ERL_NIF_TERM &out);
 int make(ErlNifEnv *env, const std::vector<int32_t>& array, ERL_NIF_TERM &out);
 int make(ErlNifEnv *env, const std::vector<long long>& array, ERL_NIF_TERM &out);
-int make(ErlNifEnv *env, const std::vector<size_t>& array, ERL_NIF_TERM &out);
+int make(ErlNifEnv *env, const std::vector<unsigned long int>& array, ERL_NIF_TERM &out);
 int make(ErlNifEnv *env, const std::vector<float>& array, ERL_NIF_TERM &out);
 int make(ErlNifEnv *env, const std::vector<double>& array, ERL_NIF_TERM &out);
 int make(ErlNifEnv *env, const std::vector<std::string>& array, ERL_NIF_TERM &out);

--- a/c_src/nif_utils.hpp
+++ b/c_src/nif_utils.hpp
@@ -10,9 +10,6 @@
 #include <cstring>
 #include <vector>
 
-#if defined(_WIN32) || defined(WIN32) || defined(__CYGWIN__) || defined(__MINGW32__) || defined(__BORLANDC__)
-#define OS_WIN
-#endif
 
 namespace erlang {
 namespace nif {
@@ -166,9 +163,7 @@ int make(ErlNifEnv *env, const char *string, ERL_NIF_TERM &out);
 int make(ErlNifEnv *env, const std::vector<uint8_t>& array, ERL_NIF_TERM &out);
 int make(ErlNifEnv *env, const std::vector<uint16_t>& array, ERL_NIF_TERM &out);
 int make(ErlNifEnv *env, const std::vector<uint32_t>& array, ERL_NIF_TERM &out);
-#ifndef OS_WIN
 int make(ErlNifEnv *env, const std::vector<unsigned long long>& array, ERL_NIF_TERM &out);
-#endif
 int make(ErlNifEnv *env, const std::vector<int8_t>& array, ERL_NIF_TERM &out);
 int make(ErlNifEnv *env, const std::vector<int16_t>& array, ERL_NIF_TERM &out);
 int make(ErlNifEnv *env, const std::vector<int32_t>& array, ERL_NIF_TERM &out);

--- a/mix.exs
+++ b/mix.exs
@@ -19,7 +19,10 @@ defmodule HNSWLib.MixProject do
       make_precompiler: {:nif, CCPrecompiler},
       make_precompiler_url: "#{@github_url}/releases/download/v#{@version}/@{artefact_filename}",
       make_precompiler_filename: "hnswlib_nif",
-      make_precompiler_nif_versions: [versions: ["2.16", "2.17"]]
+      make_precompiler_nif_versions: [versions: ["2.16", "2.17"]],
+      cc_precompiler: [
+        cleanup: "cleanup"
+      ]
     ]
   end
 


### PR DESCRIPTION
This PR should close #13 by setting the `cleanup` key for `cc_precompile` so that the private directory of this library gets cleaned up between different targets. Otherwise, it would result in archiving the same shared library file for all build targets:

<img width="699" alt="Screenshot 2023-11-21 at 13 52 37" src="https://github.com/elixir-nx/hnswlib/assets/89497197/25c70fbe-7028-4756-b414-7440153e4b28">