### PR TITLE
Reject zero for `max_elements` in `HNSWLib.Index.new/4`

### DIFF
--- a/lib/hnswlib_index.ex
+++ b/lib/hnswlib_index.ex
@@ -24,7 +24,7 @@ defmodule HNSWLib.Index do
 
     Number of dimensions for each vector.
 
-  - *max_elements*: `non_neg_integer()`.
+  - *max_elements*: `pos_integer()`.
 
     Number of maximum elements.
 
@@ -42,7 +42,7 @@ defmodule HNSWLib.Index do
   - *random_seed*: `non_neg_integer()`.
   - *allow_replace_deleted*: `boolean()`.
   """
-  @spec new(:cosine | :ip | :l2, non_neg_integer(), non_neg_integer(), [
+  @spec new(:cosine | :ip | :l2, non_neg_integer(), pos_integer(), [
           {:m, non_neg_integer()},
           {:ef_construction, non_neg_integer()},
           {:random_seed, non_neg_integer()},
@@ -50,7 +50,7 @@ defmodule HNSWLib.Index do
         ]) :: {:ok, %T{}} | {:error, String.t()}
   def new(space, dim, max_elements, opts \\ [])
       when (space == :l2 or space == :ip or space == :cosine) and is_integer(dim) and dim >= 0 and
-             is_integer(max_elements) and max_elements >= 0 do
+             is_integer(max_elements) and max_elements > 0 do
     m = Helper.get_keyword!(opts, :m, :non_neg_integer, 16)
     ef_construction = Helper.get_keyword!(opts, :ef_construction, :non_neg_integer, 200)
     random_seed = Helper.get_keyword!(opts, :random_seed, :non_neg_integer, 100)

--- a/test/hnswlib_index_test.exs
+++ b/test/hnswlib_index_test.exs
@@ -2,6 +2,15 @@ defmodule HNSWLib.Index.Test do
   use ExUnit.Case
   doctest HNSWLib.Index
 
+  test "HNSWLib.Index.new should not accept 0 for max_elements" do
+    space = :l2
+    dim = 8
+    max_elements = 0
+    assert_raise FunctionClauseError, "no function clause matching in HNSWLib.Index.new/4", fn ->
+      HNSWLib.Index.new(space, dim, max_elements)
+    end
+  end
+
   test "HNSWLib.Index.new/3 with L2-space" do
     space = :l2
     dim = 8


### PR DESCRIPTION
Hi, I saw that there was no updates for #5 for a while, so I decided to pick this job and send a PR for it.

This PR added one restriction for the `max_elements` parameter in `HNSWLib.Index.new/4`, that is, `max_elements` cannot be `0`.