### PR TITLE
[ci] speed up macOS CI and precompile builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,18 +60,62 @@ jobs:
     runs-on: macos-11
     env:
       MIX_ENV: test
+      ELIXIR_VERSION: "1.16.0"
+    strategy:
+      matrix:
+        otp_version: ["25.3.2.8", "26.2.2"]
+
+    name: macOS x86_64 - OTP ${{ matrix.otp_version }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - name: macOS setup
+      - name: Cache OTP
+        uses: actions/cache@v3
+        id: cache-otp
+        with:
+          path: ./cache/otp
+          key: ${{ runner.os }}-otp-${{ matrix.otp_version }}
+
+      - name: Download OTP
+        if: steps.cache-otp.outputs.cache-hit != 'true'
         run: |
-          brew install erlang elixir
+          mkdir -p ./cache/otp
+          curl -fSL https://github.com/cocoa-xu/otp-build/releases/download/v${{ matrix.otp_version }}/otp-x86_64-apple-darwin.tar.gz -o ./cache/otp/otp-v${{ matrix.otp_version }}-x86_64-apple-darwin.tar.gz
+          cd ./cache/otp
+          tar -xzf otp-v${{ matrix.otp_version }}-x86_64-apple-darwin.tar.gz
+
+      - name: Cache Elixir
+        id: cache-elixir
+        uses: actions/cache@v3
+        with:
+          path: ./cache/elixir
+          key: ${{ runner.os }}-elixir-${{ env.ELIXIR_VERSION }}
+
+      - name: Download and Compile Elixir
+        if: steps.cache-elixir.outputs.cache-hit != 'true'
+        run: |
+          export PATH=$(pwd)/./cache/otp/usr/local/bin:$(pwd)/./cache/elixir/elixir-${{ env.ELIXIR_VERSION }}/bin:${PATH}
+          export ERL_ROOTDIR=$(pwd)/./cache/otp/usr/local/lib/erlang
+          mkdir -p ./cache/elixir
+          curl -fSL https://github.com/elixir-lang/elixir/archive/refs/tags/v${{ env.ELIXIR_VERSION }}.tar.gz -o ./cache/elixir/elixir-${{ env.ELIXIR_VERSION }}.tar.gz
+          cd ./cache/elixir
+          tar -xzf elixir-${{ env.ELIXIR_VERSION }}.tar.gz
+          cd elixir-${{ env.ELIXIR_VERSION }}
+          make -j$(sysctl -n hw.ncpu) install
+
+      - name: Install Mix and Rebar
+        run: |
+          export PATH=$(pwd)/./cache/otp/usr/local/bin:$(pwd)/./cache/elixir/elixir-${{ env.ELIXIR_VERSION }}/bin:${PATH}
+          export ERL_ROOTDIR=$(pwd)/./cache/otp/usr/local/lib/erlang
           mix local.hex --force
           mix local.rebar --force
 
       - name: Compile and Test
         run: |
+          export PATH=$(pwd)/./cache/otp/usr/local/bin:$(pwd)/./cache/elixir/elixir-${{ env.ELIXIR_VERSION }}/bin:${PATH}
+          export ERL_ROOTDIR=$(pwd)/./cache/otp/usr/local/lib/erlang
+          
           mix deps.get
           mix elixir_make.precompile
           mix test

--- a/.github/workflows/precompile.yml
+++ b/.github/workflows/precompile.yml
@@ -58,33 +58,62 @@ jobs:
     runs-on: macos-11
     env:
       MIX_ENV: prod
-      elixir_version: "1.15.2"
+      ELIXIR_VERSION: "1.16.0"
     strategy:
       matrix:
-        otp_version: ["25.3.2.3", "26.0.2"]
+        otp_version: ["25.3.2.8", "26.2.2"]
 
     name: macOS - OTP ${{ matrix.otp_version }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - name: Install erlang and elixir
+      - name: Cache OTP
+        uses: actions/cache@v3
+        id: cache-otp
+        with:
+          path: ./cache/otp
+          key: ${{ runner.os }}-otp-${{ matrix.otp_version }}
+
+      - name: Download OTP
+        if: steps.cache-otp.outputs.cache-hit != 'true'
         run: |
-          brew install autoconf coreutils curl git openssl asdf
-          asdf plugin add erlang https://github.com/asdf-vm/asdf-erlang.git
-          asdf plugin-add elixir https://github.com/asdf-vm/asdf-elixir.git
-          export KERL_CONFIGURE_OPTIONS="--disable-debug --without-javac"
-          asdf install erlang ${{ matrix.otp_version }}
-          asdf install elixir ${{ env.elixir_version }}
-          asdf global erlang ${{ matrix.otp_version }}
-          asdf global elixir ${{ env.elixir_version }}
-          source $(brew --prefix asdf)/libexec/asdf.sh
+          mkdir -p ./cache/otp
+          curl -fSL https://github.com/cocoa-xu/otp-build/releases/download/v${{ matrix.otp_version }}/otp-x86_64-apple-darwin.tar.gz -o ./cache/otp/otp-v${{ matrix.otp_version }}-x86_64-apple-darwin.tar.gz
+          cd ./cache/otp
+          tar -xzf otp-v${{ matrix.otp_version }}-x86_64-apple-darwin.tar.gz
+
+      - name: Cache Elixir
+        id: cache-elixir
+        uses: actions/cache@v3
+        with:
+          path: ./cache/elixir
+          key: ${{ runner.os }}-elixir-${{ env.ELIXIR_VERSION }}
+  
+      - name: Download and Compile Elixir
+        if: steps.cache-elixir.outputs.cache-hit != 'true'
+        run: |
+          export PATH=$(pwd)/./cache/otp/usr/local/bin:$(pwd)/./cache/elixir/elixir-${{ env.ELIXIR_VERSION }}/bin:${PATH}
+          export ERL_ROOTDIR=$(pwd)/./cache/otp/usr/local/lib/erlang
+          mkdir -p ./cache/elixir
+          curl -fSL https://github.com/elixir-lang/elixir/archive/refs/tags/v${{ env.ELIXIR_VERSION }}.tar.gz -o ./cache/elixir/elixir-${{ env.ELIXIR_VERSION }}.tar.gz
+          cd ./cache/elixir
+          tar -xzf elixir-${{ env.ELIXIR_VERSION }}.tar.gz
+          cd elixir-${{ env.ELIXIR_VERSION }}
+          make -j$(sysctl -n hw.ncpu) install
+
+      - name: Install Mix and Rebar
+        run: |
+          export PATH=$(pwd)/./cache/otp/usr/local/bin:$(pwd)/./cache/elixir/elixir-${{ env.ELIXIR_VERSION }}/bin:${PATH}
+          export ERL_ROOTDIR=$(pwd)/./cache/otp/usr/local/lib/erlang
           mix local.hex --force
           mix local.rebar --force
 
       - name: Precompile
         run: |
-          source $(brew --prefix asdf)/libexec/asdf.sh
+          export PATH=$(pwd)/./cache/otp/usr/local/bin:$(pwd)/./cache/elixir/elixir-${{ env.ELIXIR_VERSION }}/bin:${PATH}
+          export ERL_ROOTDIR=$(pwd)/./cache/otp/usr/local/lib/erlang
+
           export ELIXIR_MAKE_CACHE_DIR=$(pwd)/cache
           mkdir -p "${ELIXIR_MAKE_CACHE_DIR}"
           mix deps.get


### PR DESCRIPTION
This PR speeds up macOS CI and precompile builds by utilising precompiled OTP binaries, which used to take about 30 minutes just to install erlang and elixir via homebrew.