### PR TITLE
deps: Relax elixir_make version constraint

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -34,7 +34,7 @@ defmodule HNSWLib.MixProject do
     [
       # compilation
       {:cc_precompiler, "~> 0.1.0"},
-      {:elixir_make, "~> 0.8.0"},
+      {:elixir_make, "~> 0.8"},
 
       # runtime
       {:nx, "~> 0.5"},


### PR DESCRIPTION
## Summary

Changes `elixir_make` dependency from `~> 0.8.0` to `~> 0.8`.

This allows compatibility with elixir_make 0.9.x (released November 2024) while maintaining support for 0.8.x versions.

The current constraint `~> 0.8.0` means `>= 0.8.0 and < 0.9.0`, which forces downstream projects using elixir_make 0.9+ to add `override: true` to resolve the conflict.